### PR TITLE
Fixing temp folder errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,11 +705,11 @@ impl LocalEnvironmentBuilder {
 
     /// Finalizes the environment.
     pub fn build(&mut self) -> LocalEnvironment {
-        let tmpdir = TempDir::new().expect("make tempdir");
+        let tmpdir = Path::new("/tmp/");
 
         let bank = Bank::new_with_paths(
             &self.config,
-            vec![tmpdir.path().to_path_buf()],
+            vec![tmpdir.to_path_buf()],
             &[],
             None,
             Some(&Builtins {


### PR DESCRIPTION
This request is aiming at fixing temp folder errors creating files mentioned in https://github.com/neodyme-labs/solana-poc-framework/issues/2 by setting directory to "/tmp/" thus avoiding the problem of directories getting deleted quickly.