### PR TITLE
add advance_blockhash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,6 +345,24 @@ impl LocalEnvironment {
     pub fn bank(&mut self) -> &mut Bank {
         &mut self.bank
     }
+
+    /// Advance the bank to the next blockhash.
+    pub fn advance_blockhash(&self) -> Hash {
+        let parent_distance = if self.bank.slot() == 0 {
+            1
+        } else {
+            self.bank.slot() - self.bank.parent_slot()
+        };
+
+        for _ in 0..parent_distance {
+            let last_blockhash = self.bank.last_blockhash();
+            while self.bank.last_blockhash() == last_blockhash {
+                self.bank.register_tick(&Hash::new_unique())
+            }
+        }
+
+        self.get_recent_blockhash()
+    }
 }
 
 impl Environment for LocalEnvironment {
@@ -732,10 +750,14 @@ impl LocalEnvironmentBuilder {
             false,
             None,
         );
-        LocalEnvironment {
+
+        let env = LocalEnvironment {
             bank,
             faucet: clone_keypair(&self.faucet),
-        }
+        };
+        env.advance_blockhash();
+
+        env
     }
 }
 


### PR DESCRIPTION
add a method to LocalEnvironment to move to a subsequent blockhash
adapted from fill_bank_with_ticks() in solana >=1.9

i added this to avoid having to munge transactions or use nonce mode to get around duplicate transaction errors. note this uses `Hash::new_unique()` so blockhashes are (at least on my machine?) advance deterministically now, which might be useful/convenient